### PR TITLE
fix: 結果ボタンを常時表示し完了時に活性化

### DIFF
--- a/src/components/Meeting.tsx
+++ b/src/components/Meeting.tsx
@@ -225,16 +225,19 @@ export function Meeting({ hearing, onReset }: MeetingProps) {
         <div ref={bottomRef} />
       </div>
 
-      {phase === "done" && (
-        <div className="pt-4 border-t border-amber-200 animate-fade-in">
-          <button
-            onClick={() => setPhase("pokapoka")}
-            className="w-full bg-green-600 hover:bg-green-700 active:bg-green-800 text-white text-lg py-5 rounded-xl cursor-pointer font-medium"
-          >
-            結果を見るにゃ 🐾
-          </button>
-        </div>
-      )}
+      <div className="pt-4 border-t border-amber-200">
+        <button
+          onClick={() => setPhase("pokapoka")}
+          disabled={phase !== "done"}
+          className={`w-full text-white text-lg py-5 rounded-xl font-medium transition-colors ${
+            phase === "done"
+              ? "bg-green-600 hover:bg-green-700 active:bg-green-800 cursor-pointer"
+              : "bg-gray-300 cursor-not-allowed"
+          }`}
+        >
+          {phase === "done" ? "結果を見るにゃ 🐾" : "会議中にゃ..."}
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 「結果を見るにゃ」ボタンを会議開始時から常に表示するように変更
- ストリーミング中はグレーアウト（disabled）で「会議中にゃ...」と表示
- 会議完了後に緑色に切り替わりタップ可能に

## Test plan
- [ ] 会議画面に遷移した時点でボタンが表示されていること
- [ ] ストリーミング中はボタンがグレーで押せないこと
- [ ] ストリーミング完了後にボタンが緑に変わり押せること

🤖 Generated with [Claude Code](https://claude.com/claude-code)